### PR TITLE
Run heading text through safe to decode HTML

### DIFF
--- a/.app/_includes/partials/panel.njk
+++ b/.app/_includes/partials/panel.njk
@@ -9,7 +9,7 @@
       {% for item in toc %}
       <li style="--level: {{ item.level }}" class="toc__item">
         <a href="#{{ item.id }}" class="toc__link">
-          {{ item.text }}
+          {{ item.text | safe }}
         </a>
       </li>
       {% endfor %}


### PR DESCRIPTION
Hit this while using the project. I have a page with the following heading that has quotes:

```md

## Why "Intersect"?

Some notes about this

```

The TOC will render as `Why &quot;Intersect&quot;?`

By passing `text` to the `safe` filter it will render correctly as `Why "Intersect"?`