### PR TITLE
Set color-scheme to dark in dark mode

### DIFF
--- a/.app/css/3-global/theme.scss
+++ b/.app/css/3-global/theme.scss
@@ -12,11 +12,13 @@ $color: null !default;
 
 body {
   &[data-theme="dark"] {
+    color-scheme: dark;
     @include tokens.build(tokens-color.build($color, $dark: true));
   }
 
   &[data-theme="system"] {
     @media (prefers-color-scheme: dark) {
+      color-scheme: dark;
       @include tokens.build(tokens-color.build($color, $dark: true));
     }
   }


### PR DESCRIPTION
Hello,

This small pull request is a small dark theme "fix".

By altering the `color-scheme` property, we can force the browser UI to be dark in dark themes (in this case: recolor the scrollbar at the sidebar).

Nice job,
Adam

![image](https://github.com/rothsandro/eleventy-notes/assets/5145299/d9e63982-921a-4068-a3cf-54f101627cbc)
