### PR TITLE
feat: search input outline color

### DIFF
--- a/.app/css/4-components/search.scss
+++ b/.app/css/4-components/search.scss
@@ -23,6 +23,10 @@
     background-color: var(--color-neutral-bg-hover);
   }
 
+  &:focus-visible {  
+    outline: var(--color-primary-text) solid 2px;
+  }
+
   &::placeholder {
     color: var(--color-neutral-placeholder);
   }


### PR DESCRIPTION
<img width="440" alt="image" src="https://github.com/rothsandro/eleventy-notes/assets/47499684/7339a0b3-3553-4ac3-a38c-ef905e864448">

Default browser styling can make the input field look quite ugly. This matches it with the same accent color used in other components like the theme switcher, links, and menu:

<img width="460" alt="image" src="https://github.com/rothsandro/eleventy-notes/assets/47499684/91168fb8-4cc4-49f2-b3e6-940dc0f97cfb">
